### PR TITLE
feat: use class name in rendering

### DIFF
--- a/src/Filedropper.tsx
+++ b/src/Filedropper.tsx
@@ -19,7 +19,8 @@ export function Filedropper({
     maxNumFilesToUpload,
     acceptedFileTypes,
     acceptedFilesText,
-    acceptedFileSizeText
+    acceptedFileSizeText,
+    class: className
 }: FiledropperContainerProps): ReactElement {
 
     if (fileDataAttr === null || fileDataAttr === undefined || fileDataAttr.status != ValueStatus.Available || defaultText?.status != ValueStatus.Available || dragText?.status != ValueStatus.Available || buttonText?.status != ValueStatus.Available || acceptedFilesText?.status != ValueStatus.Available || acceptedFileSizeText?.status != ValueStatus.Available ) {
@@ -46,7 +47,7 @@ export function Filedropper({
     }
 
     return (
-        <div className="dropzoneWrapper">
+        <div className={"dropzoneWrapper " + className}>
             <FileDropperUI
                 fileDataAttr={fileDataAttr}
                 onDropAction={onDropAction}


### PR DESCRIPTION
To customize the styling of the file dropper the user should be able to use the standard Mendix 'Class' and 'Dynamic classes' inputs. The PR will take the input classes and render them in the wrapper.

![image](https://github.com/user-attachments/assets/de31db82-0863-4f20-9598-6277edfccfe8)

