### PR TITLE
feat: input accept mime and file extension

### DIFF
--- a/src/Filedropper.tsx
+++ b/src/Filedropper.tsx
@@ -28,7 +28,7 @@ export function Filedropper({
     }
 
     const getAcceptedFileTypes = () => {
-        return Array.from(acceptedFileTypes.split(","));
+        return Array.from(acceptedFileTypes.split(","), type => type.toLowerCase().trim());
     }
 
     const renderUploadImage = () => {

--- a/src/Filedropper.xml
+++ b/src/Filedropper.xml
@@ -70,7 +70,7 @@
             </property>
             <property key="acceptedFileTypes" type="string" required="false">
                 <caption>Accepted files type</caption>
-                <description>Leave empty to accept all files or enter comma separated values. e.g. image/png, image/jpg, application/pdf, etc. Wildcard accepted as image/*, application/*, etc. Mime types - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+                <description>Leave empty to accept all files mime types or file extension enter comma separated values. e.g. image/png, image/jpg, application/pdf, etc. Wildcard accepted as image/*, application/*, .docx, .pdf etc. Mime types - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
                 </description>
             </property>
             <property key="acceptedFilesText" type="textTemplate" required="false">

--- a/src/components/FileDropperUI.tsx
+++ b/src/components/FileDropperUI.tsx
@@ -62,9 +62,14 @@ export function FileDropperUI({
                 }
             }
         }
-        if(acceptedFileTypes.find((item) => item.toLowerCase().trim() === fileType)){
+        if(acceptedFileTypes.find((item) => item === fileType)){
             return true;
         }
+        const extension = "." + fileType.split("/")[1];
+        if(acceptedFileTypes.find((item) => item === extension)){
+            return true;
+        }
+
         return false;
     }
 
@@ -188,7 +193,7 @@ export function FileDropperUI({
 
     return (
         <div ref={drop} onDragEnter={handleDrag} onDragLeave={handleDrag} onDragOver={handleDrag} onDrop={handleDrop}>
-            <input ref={inputRef} type="file" id="input-file-upload" multiple={true} onChange={handleChange} />
+            <input ref={inputRef} type="file" id="input-file-upload" accept={acceptedFileTypes.join(",")} multiple={true} onChange={handleChange} />
             <label htmlFor="input-file-upload" className={dragActive ? "dropzone drag" : "dropzone"}>
                 <div>
                     {dragActive ? <div /> : uploadImage}


### PR DESCRIPTION
The input button, can make file selection easier, by filtering using the `accept` attribute 
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept

This can also take file types, and therefore adding acceptance filtering as wel.

![image](https://github.com/user-attachments/assets/9816e555-b566-48ca-aba9-cad47b298b2a)
